### PR TITLE
Add Partner Merchants management and details

### DIFF
--- a/app/dashboard/partner-merchants/[id]/page.tsx
+++ b/app/dashboard/partner-merchants/[id]/page.tsx
@@ -1,0 +1,383 @@
+"use client"
+
+import React, { useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { DashboardBreadcrumbs } from '@/components/dashboard/DashboardBreadcrumbs'
+import { DashboardPageHeader } from '@/components/dashboard/DashboardPageHeader'
+import { DashboardPageLayout } from '@/components/dashboard/DashboardPageLayout'
+import { getDashboardPageCrumbs } from '@/lib/constants/dashboard-page-meta'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  AlertTriangle,
+  ArrowLeft,
+  RefreshCw,
+  ShieldBan,
+  ShieldCheck,
+} from 'lucide-react'
+import { usePermissions, PERMISSIONS } from '@/lib/hooks/usePermissions'
+import {
+  useBlockPartnerMerchant,
+  usePartnerMerchant,
+  usePartnerMerchantTransactions,
+} from '@/lib/hooks/usePartnerMerchants'
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '—'
+  return new Date(value).toLocaleString('en-UG', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function getStatusBadge(status: string) {
+  const normalized = status.toUpperCase()
+  if (normalized === 'ACTIVE') return <Badge className="bg-green-500">Active</Badge>
+  if (normalized === 'INACTIVE') return <Badge variant="secondary">Inactive</Badge>
+  if (normalized === 'BLOCKED') return <Badge variant="destructive">Blocked</Badge>
+  return <Badge variant="outline">{status}</Badge>
+}
+
+export default function PartnerMerchantDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const merchantId = String(params.id ?? '')
+  const [txPage, setTxPage] = useState(1)
+  const [blockReason, setBlockReason] = useState('')
+  const [actionError, setActionError] = useState('')
+
+  const { hasPermission } = usePermissions()
+  const canView = hasPermission(PERMISSIONS.PARTNERS_VIEW)
+
+  const { data: merchant, isLoading, error, refetch } = usePartnerMerchant(merchantId)
+  const {
+    data: txData,
+    isLoading: txLoading,
+    refetch: refetchTx,
+  } = usePartnerMerchantTransactions(merchantId, txPage, 20)
+  const blockMutation = useBlockPartnerMerchant()
+
+  const handleBlockToggle = async () => {
+    if (!merchant) return
+    setActionError('')
+    const isBlocked = merchant.status.toUpperCase() === 'BLOCKED'
+    try {
+      await blockMutation.mutateAsync({
+        merchantId: merchant.merchantId,
+        blocked: !isBlocked,
+        reason: !isBlocked ? blockReason || undefined : undefined,
+      })
+      setBlockReason('')
+      await refetch()
+    } catch (err: any) {
+      setActionError(err?.response?.data?.message || err?.message || 'Action failed')
+    }
+  }
+
+  if (!canView) {
+    return (
+      <DashboardPageLayout>
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <div className="text-center">
+            <AlertTriangle className="h-16 w-16 text-orange-500 mx-auto mb-4" />
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">Access Denied</h1>
+            <p className="text-gray-600">You do not have permission to view this merchant.</p>
+          </div>
+        </div>
+      </DashboardPageLayout>
+    )
+  }
+
+  if (error) {
+    return (
+      <DashboardPageLayout>
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <div className="text-center">
+            <AlertTriangle className="h-16 w-16 text-red-500 mx-auto mb-4" />
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">Merchant Not Found</h1>
+            <Button variant="outline" onClick={() => router.push('/dashboard/partner-merchants')}>
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to list
+            </Button>
+          </div>
+        </div>
+      </DashboardPageLayout>
+    )
+  }
+
+  const isBlocked = merchant?.status?.toUpperCase() === 'BLOCKED'
+
+  return (
+    <DashboardPageLayout>
+      <DashboardBreadcrumbs items={getDashboardPageCrumbs('partner-merchants/[id]')} />
+      <DashboardPageHeader
+        title={merchant?.merchantName || 'Partner Merchant'}
+        description={merchant ? `merchantId: ${merchant.merchantId}` : 'Loading...'}
+        actions={
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => router.push('/dashboard/partner-merchants')}
+            >
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                refetch()
+                refetchTx()
+              }}
+              disabled={isLoading}
+            >
+              <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
+              Refresh
+            </Button>
+          </div>
+        }
+      />
+
+      {isLoading || !merchant ? (
+        <Card>
+          <CardContent className="p-8 text-center text-gray-500">Loading merchant...</CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <Card className="lg:col-span-2">
+              <CardHeader>
+                <CardTitle>Profile</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <p className="text-gray-500">Status</p>
+                  <div className="mt-1">{getStatusBadge(merchant.status)}</div>
+                </div>
+                <div>
+                  <p className="text-gray-500">Industry</p>
+                  <p className="font-medium">{merchant.industry}</p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Partner</p>
+                  <p className="font-medium">
+                    {merchant.apiPartner?.partnerName || merchant.apiPartnerId}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Base merchant</p>
+                  <p className="font-medium">{merchant.isBaseMerchant ? 'Yes' : 'No'}</p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Contact email</p>
+                  <p className="font-medium">{merchant.contactEmail || '—'}</p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Contact phone</p>
+                  <p className="font-medium">{merchant.contactPhone || '—'}</p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Contact person</p>
+                  <p className="font-medium">{merchant.contactPerson || '—'}</p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Created</p>
+                  <p className="font-medium">{formatDateTime(merchant.createdAt)}</p>
+                </div>
+                {isBlocked && (
+                  <>
+                    <div>
+                      <p className="text-gray-500">Blocked at</p>
+                      <p className="font-medium">{formatDateTime(merchant.blockedAt)}</p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">Block reason</p>
+                      <p className="font-medium">{merchant.blockedReason || '—'}</p>
+                    </div>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>{isBlocked ? 'Unblock merchant' : 'Block merchant'}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm text-gray-600">
+                  Blocking stops transactions for this merchant only. The partner and sibling
+                  merchants stay unaffected.
+                </p>
+                {!isBlocked && (
+                  <div>
+                    <Label htmlFor="reason">Reason (optional)</Label>
+                    <Input
+                      id="reason"
+                      value={blockReason}
+                      onChange={(e) => setBlockReason(e.target.value)}
+                      placeholder="e.g. Suspected fraud"
+                    />
+                  </div>
+                )}
+                {actionError && <p className="text-sm text-red-600">{actionError}</p>}
+                <Button
+                  variant={isBlocked ? 'default' : 'destructive'}
+                  className="w-full"
+                  disabled={blockMutation.isPending}
+                  onClick={handleBlockToggle}
+                >
+                  {isBlocked ? (
+                    <>
+                      <ShieldCheck className="h-4 w-4 mr-2" />
+                      Unblock
+                    </>
+                  ) : (
+                    <>
+                      <ShieldBan className="h-4 w-4 mr-2" />
+                      Block merchant
+                    </>
+                  )}
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>KYC documents</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Requirement</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Document</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(merchant.documents || []).length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center py-8 text-gray-500">
+                        No documents on file.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    (merchant.documents || []).map((doc) => (
+                      <TableRow key={doc.id}>
+                        <TableCell className="font-medium">{doc.documentType}</TableCell>
+                        <TableCell>{doc.requirement}</TableCell>
+                        <TableCell>{doc.status}</TableCell>
+                        <TableCell>
+                          {doc.documentUrl ? (
+                            <a
+                              href={doc.documentUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="text-blue-600 hover:underline"
+                            >
+                              Open
+                            </a>
+                          ) : (
+                            '—'
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Transactions</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Reference</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Amount</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {txLoading ? (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center py-8 text-gray-500">
+                        Loading transactions...
+                      </TableCell>
+                    </TableRow>
+                  ) : (txData?.items || []).length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center py-8 text-gray-500">
+                        No transactions attributed to this merchant yet.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    (txData?.items || []).map((tx) => (
+                      <TableRow key={tx.id}>
+                        <TableCell className="font-mono text-xs">
+                          {tx.reference || tx.id.slice(0, 8)}
+                        </TableCell>
+                        <TableCell>{tx.type}</TableCell>
+                        <TableCell>{tx.status}</TableCell>
+                        <TableCell>
+                          {Number(tx.amount).toLocaleString()} {tx.currency}
+                        </TableCell>
+                        <TableCell>{formatDateTime(tx.createdAt)}</TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+              {txData && txData.pagination.totalPages > 1 && (
+                <div className="flex items-center justify-between px-4 py-3 border-t">
+                  <p className="text-sm text-gray-500">
+                    Page {txData.pagination.page} of {txData.pagination.totalPages}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={txPage <= 1}
+                      onClick={() => setTxPage((p) => Math.max(1, p - 1))}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={txPage >= txData.pagination.totalPages}
+                      onClick={() => setTxPage((p) => p + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </DashboardPageLayout>
+  )
+}

--- a/app/dashboard/partner-merchants/page.tsx
+++ b/app/dashboard/partner-merchants/page.tsx
@@ -1,0 +1,390 @@
+"use client"
+
+import React, { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { DashboardBreadcrumbs } from '@/components/dashboard/DashboardBreadcrumbs'
+import { DashboardPageHeader } from '@/components/dashboard/DashboardPageHeader'
+import { DashboardPageLayout } from '@/components/dashboard/DashboardPageLayout'
+import { getDashboardPageCrumbs } from '@/lib/constants/dashboard-page-meta'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  AlertTriangle,
+  Building2,
+  RefreshCw,
+  Search,
+  Store,
+  ShieldBan,
+} from 'lucide-react'
+import { usePermissions, PERMISSIONS } from '@/lib/hooks/usePermissions'
+import { useGatewayPartners, type GatewayPartner } from '@/lib/hooks/useGatewayPartners'
+import { usePartnerMerchants } from '@/lib/hooks/usePartnerMerchants'
+
+const INDUSTRIES = [
+  'Betting',
+  'E-commerce',
+  'Retail',
+  'Supermarket',
+  'Pharmacy',
+  'Fuel Station',
+  'Utility Services',
+  'Education',
+  'SACCO',
+  'Microfinance',
+  'Other',
+]
+
+function formatDate(value?: string | null) {
+  if (!value) return '—'
+  return new Date(value).toLocaleDateString('en-UG', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function getStatusBadge(status: string) {
+  const normalized = status.toUpperCase()
+  if (normalized === 'ACTIVE') {
+    return <Badge className="bg-green-500">Active</Badge>
+  }
+  if (normalized === 'INACTIVE') {
+    return <Badge variant="secondary">Inactive</Badge>
+  }
+  if (normalized === 'BLOCKED') {
+    return <Badge variant="destructive">Blocked</Badge>
+  }
+  return <Badge variant="outline">{status}</Badge>
+}
+
+export default function PartnerMerchantsPage() {
+  const router = useRouter()
+  const [searchTerm, setSearchTerm] = useState('')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [industryFilter, setIndustryFilter] = useState('all')
+  const [partnerFilter, setPartnerFilter] = useState('all')
+  const [page, setPage] = useState(1)
+
+  const { hasPermission } = usePermissions()
+  const canView = hasPermission(PERMISSIONS.PARTNERS_VIEW)
+
+  const { data: partnersResponse } = useGatewayPartners(1, 200)
+  const partners: GatewayPartner[] = partnersResponse?.data ?? []
+
+  const listParams = useMemo(
+    () => ({
+      apiPartnerId: partnerFilter === 'all' ? undefined : partnerFilter,
+      industry: industryFilter === 'all' ? undefined : industryFilter,
+      status: statusFilter === 'all' ? undefined : statusFilter,
+      search: searchTerm.trim() || undefined,
+      page,
+      limit: 20,
+    }),
+    [partnerFilter, industryFilter, statusFilter, searchTerm, page],
+  )
+
+  const { data, isLoading, error, refetch } = usePartnerMerchants(listParams)
+  const items = data?.items ?? []
+  const pagination = data?.pagination
+
+  const stats = useMemo(() => {
+    const active = items.filter((m) => m.status.toUpperCase() === 'ACTIVE').length
+    const blocked = items.filter((m) => m.status.toUpperCase() === 'BLOCKED').length
+    const inactive = items.filter((m) => m.status.toUpperCase() === 'INACTIVE').length
+    return {
+      total: pagination?.total ?? items.length,
+      active,
+      blocked,
+      inactive,
+    }
+  }, [items, pagination])
+
+  if (!canView) {
+    return (
+      <DashboardPageLayout>
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <div className="text-center">
+            <AlertTriangle className="h-16 w-16 text-orange-500 mx-auto mb-4" />
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">Access Denied</h1>
+            <p className="text-gray-600">
+              You do not have permission to view partner merchants.
+            </p>
+          </div>
+        </div>
+      </DashboardPageLayout>
+    )
+  }
+
+  return (
+    <DashboardPageLayout>
+      <DashboardBreadcrumbs items={getDashboardPageCrumbs('partner-merchants')} />
+      <DashboardPageHeader
+        title="Partner Merchants"
+        description="Merchants registered under API partners — KYC, status, and transaction attribution"
+        actions={
+          <Button variant="outline" onClick={() => refetch()} disabled={isLoading}>
+            <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        }
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center space-x-4">
+              <div className="w-12 h-12 bg-blue-500 rounded-xl flex items-center justify-center">
+                <Store className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-gray-500">Total</h3>
+                <p className="text-2xl font-bold text-gray-900">{stats.total}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center space-x-4">
+              <div className="w-12 h-12 bg-green-500 rounded-xl flex items-center justify-center">
+                <Building2 className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-gray-500">Active (page)</h3>
+                <p className="text-2xl font-bold text-green-600">{stats.active}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center space-x-4">
+              <div className="w-12 h-12 bg-slate-500 rounded-xl flex items-center justify-center">
+                <Building2 className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-gray-500">Inactive (page)</h3>
+                <p className="text-2xl font-bold text-slate-700">{stats.inactive}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center space-x-4">
+              <div className="w-12 h-12 bg-red-500 rounded-xl flex items-center justify-center">
+                <ShieldBan className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-gray-500">Blocked (page)</h3>
+                <p className="text-2xl font-bold text-red-600">{stats.blocked}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mb-6">
+        <CardContent className="p-6">
+          <div className="flex flex-col lg:flex-row gap-4">
+            <div className="flex-1">
+              <Label htmlFor="search">Search</Label>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                <Input
+                  id="search"
+                  placeholder="Search by merchant name or merchantId..."
+                  value={searchTerm}
+                  onChange={(e) => {
+                    setPage(1)
+                    setSearchTerm(e.target.value)
+                  }}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+            <div className="lg:w-48">
+              <Label>Status</Label>
+              <Select
+                value={statusFilter}
+                onValueChange={(v) => {
+                  setPage(1)
+                  setStatusFilter(v)
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Status" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All statuses</SelectItem>
+                  <SelectItem value="ACTIVE">Active</SelectItem>
+                  <SelectItem value="INACTIVE">Inactive</SelectItem>
+                  <SelectItem value="BLOCKED">Blocked</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="lg:w-56">
+              <Label>Industry</Label>
+              <Select
+                value={industryFilter}
+                onValueChange={(v) => {
+                  setPage(1)
+                  setIndustryFilter(v)
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Industry" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All industries</SelectItem>
+                  {INDUSTRIES.map((industry) => (
+                    <SelectItem key={industry} value={industry}>
+                      {industry}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="lg:w-56">
+              <Label>Partner</Label>
+              <Select
+                value={partnerFilter}
+                onValueChange={(v) => {
+                  setPage(1)
+                  setPartnerFilter(v)
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Partner" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All partners</SelectItem>
+                  {partners.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.partnerName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {error ? (
+        <Card>
+          <CardContent className="p-8 text-center">
+            <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-3" />
+            <p className="text-gray-700 mb-4">Failed to load partner merchants.</p>
+            <Button onClick={() => refetch()}>Try again</Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Merchant</TableHead>
+                  <TableHead>Partner</TableHead>
+                  <TableHead>Industry</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Base</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center py-10 text-gray-500">
+                      Loading merchants...
+                    </TableCell>
+                  </TableRow>
+                ) : items.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center py-10 text-gray-500">
+                      No partner merchants found.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  items.map((merchant) => (
+                    <TableRow
+                      key={merchant.id}
+                      className="cursor-pointer hover:bg-gray-50"
+                      onClick={() =>
+                        router.push(`/dashboard/partner-merchants/${merchant.merchantId}`)
+                      }
+                    >
+                      <TableCell>
+                        <div className="font-medium text-gray-900">{merchant.merchantName}</div>
+                        <div className="text-xs text-gray-500 font-mono">
+                          {merchant.merchantId}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {merchant.apiPartner?.partnerName || merchant.apiPartnerId}
+                      </TableCell>
+                      <TableCell>{merchant.industry}</TableCell>
+                      <TableCell>{getStatusBadge(merchant.status)}</TableCell>
+                      <TableCell>
+                        {merchant.isBaseMerchant ? (
+                          <Badge variant="outline">Base</Badge>
+                        ) : (
+                          '—'
+                        )}
+                      </TableCell>
+                      <TableCell>{formatDate(merchant.createdAt)}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+            {pagination && pagination.totalPages > 1 && (
+              <div className="flex items-center justify-between px-4 py-3 border-t">
+                <p className="text-sm text-gray-500">
+                  Page {pagination.page} of {pagination.totalPages} ({pagination.total} total)
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page <= 1}
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page >= pagination.totalPages}
+                    onClick={() => setPage((p) => p + 1)}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </DashboardPageLayout>
+  )
+}

--- a/components/dashboard/Navbar.tsx
+++ b/components/dashboard/Navbar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState, useRef, useEffect } from 'react'
-import { Bell, Search, Settings, User, LogOut, Home,Users, CreditCard, Shield, FileText, Database, Cog, DollarSign, AlertCircle, BarChart3, ChevronLeft, ChevronRight, Package, Wallet, Activity, Globe, Layers, Building2, Images, EyeOff, Ticket, Banknote } from 'lucide-react'
+import { Bell, Search, Settings, User, LogOut, Home,Users, CreditCard, Shield, FileText, Database, Cog, DollarSign, AlertCircle, BarChart3, ChevronLeft, ChevronRight, Package, Wallet, Activity, Globe, Layers, Building2, Images, EyeOff, Ticket, Banknote, Store } from 'lucide-react'
 import { SearchInput } from '@/components/ui/search-input'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -251,7 +251,7 @@ const Navbar = () => {
                   <Link 
                     href="/dashboard" 
                     className={`nav-slider-item ${
-                      isActive('/dashboard') && !isActive('/dashboard/transactions') && !isActive('/dashboard/users') && !isActive('/dashboard/analytics') && !isActive('/dashboard/activity') && !isActive('/dashboard/revenue-tax') && !isActive('/dashboard/reports') && !isActive('/dashboard/security') && !isActive('/dashboard/settings') && !isActive('/dashboard/customers') && !isActive('/dashboard/cards') && !isActive('/dashboard/gateway-partners') && !isActive('/dashboard/rukasente-loans') && !isActive('/dashboard/saccos') && !isActive('/dashboard/merchant-events') && !isActive('/dashboard/carousel')
+                      isActive('/dashboard') && !isActive('/dashboard/transactions') && !isActive('/dashboard/users') && !isActive('/dashboard/analytics') && !isActive('/dashboard/activity') && !isActive('/dashboard/revenue-tax') && !isActive('/dashboard/reports') && !isActive('/dashboard/security') && !isActive('/dashboard/settings') && !isActive('/dashboard/customers') && !isActive('/dashboard/cards') && !isActive('/dashboard/gateway-partners') && !isActive('/dashboard/rukasente-loans') && !isActive('/dashboard/saccos') && !isActive('/dashboard/partner-merchants') && !isActive('/dashboard/merchant-events') && !isActive('/dashboard/carousel')
                         ? 'active'
                         : ''
                     }`}
@@ -293,7 +293,7 @@ const Navbar = () => {
                       <Link 
                         href="/dashboard/finance" 
                         className={`nav-slider-item ${
-                          (isActive('/dashboard/finance') || isActive('/dashboard/finance/tariffs') || isActive('/dashboard/finance/tariffs-new') || isActive('/dashboard/finance/partners') || isActive('/dashboard/finance/transaction-mapping') || isActive('/dashboard/finance/routing-rules') || isActive('/dashboard/transaction-modes') || isActive('/dashboard/wallet') || isActive('/dashboard/platform-revenue') || isActive('/dashboard/system-wallets') || isActive('/dashboard/transactions') || isActive('/dashboard/reports')) && !isActive('/dashboard/gateway-partners') && !isActive('/dashboard/saccos')
+                          (isActive('/dashboard/finance') || isActive('/dashboard/finance/tariffs') || isActive('/dashboard/finance/tariffs-new') || isActive('/dashboard/finance/partners') || isActive('/dashboard/finance/transaction-mapping') || isActive('/dashboard/finance/routing-rules') || isActive('/dashboard/transaction-modes') || isActive('/dashboard/wallet') || isActive('/dashboard/platform-revenue') || isActive('/dashboard/system-wallets') || isActive('/dashboard/transactions') || isActive('/dashboard/reports')) && !isActive('/dashboard/gateway-partners') && !isActive('/dashboard/saccos') && !isActive('/dashboard/partner-merchants')
                             ? 'active'
                             : ''
                         }`}
@@ -361,6 +361,20 @@ const Navbar = () => {
                     >
                       <Building2 className="nav-icon" />
                       <span>SACCOs</span>
+                    </Link>
+                  </PermissionGuard>
+                )}
+
+                {isVisible('partner-merchants') && (
+                  <PermissionGuard permission={PERMISSIONS.PARTNERS_VIEW}>
+                    <Link
+                      href="/dashboard/partner-merchants"
+                      className={`nav-slider-item ${
+                        isActive('/dashboard/partner-merchants') ? 'active' : ''
+                      }`}
+                    >
+                      <Store className="nav-icon" />
+                      <span>Partner Merchants</span>
                     </Link>
                   </PermissionGuard>
                 )}

--- a/lib/constants/dashboard-page-meta.ts
+++ b/lib/constants/dashboard-page-meta.ts
@@ -73,6 +73,12 @@ export const DASHBOARD_PAGE_CRUMBS: Record<string, DashboardBreadcrumbItem[]> = 
     { label: 'SACCOs', href: '/dashboard/saccos' },
     { label: 'Details' },
   ],
+  'partner-merchants': [root, { label: 'Partner Merchants' }],
+  'partner-merchants/[id]': [
+    root,
+    { label: 'Partner Merchants', href: '/dashboard/partner-merchants' },
+    { label: 'Details' },
+  ],
   'merchant-events': [root, { label: 'Merchant Events' }],
   'merchant-events/list': [root, { label: 'Merchant Events', href: '/dashboard/merchant-events' }, { label: 'All Events' }],
   'merchant-events/orders': [root, { label: 'Merchant Events', href: '/dashboard/merchant-events' }, { label: 'Orders' }],

--- a/lib/hooks/useNavVisibility.ts
+++ b/lib/hooks/useNavVisibility.ts
@@ -8,6 +8,7 @@ export const NAV_ITEMS = [
   { key: 'gateway-partners', label: 'Gateway Partners', description: 'External gateway partner management' },
   { key: 'rukasente-loans', label: 'RukaSente Loans', description: 'Active loan borrowers and manual collections' },
   { key: 'saccos', label: 'SACCOs', description: 'View SACCO institutions onboarded under partners' },
+  { key: 'partner-merchants', label: 'Partner Merchants', description: 'Merchants registered under API partners' },
   { key: 'merchant-events', label: 'Merchant Events', description: 'Platform-wide merchant events monitoring' },
   { key: 'users', label: 'Users', description: 'Staff user management' },
   { key: 'customers', label: 'Customers', description: 'Customer account management' },

--- a/lib/hooks/usePartnerMerchants.ts
+++ b/lib/hooks/usePartnerMerchants.ts
@@ -1,0 +1,212 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '@/lib/axios'
+
+export type PartnerMerchantStatus = 'ACTIVE' | 'INACTIVE' | 'BLOCKED'
+
+export interface PartnerMerchantDocument {
+  id: string
+  partnerMerchantId: string
+  documentType: string
+  documentUrl?: string | null
+  documentNumber?: string | null
+  requirement: string
+  status: string
+  rejectionReason?: string | null
+  verifiedBy?: string | null
+  verifiedAt?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PartnerMerchantPartner {
+  id: string
+  partnerName: string
+  partnerType?: string
+  contactEmail?: string
+}
+
+export interface PartnerMerchant {
+  id: string
+  merchantId: string
+  apiPartnerId: string
+  merchantName: string
+  industry: string
+  contactEmail?: string | null
+  contactPhone?: string | null
+  contactPerson?: string | null
+  status: PartnerMerchantStatus | string
+  isBaseMerchant: boolean
+  blockedAt?: string | null
+  blockedReason?: string | null
+  blockedBy?: string | null
+  createdAt: string
+  updatedAt: string
+  documents?: PartnerMerchantDocument[]
+  apiPartner?: PartnerMerchantPartner
+}
+
+export interface PartnerMerchantListResponse {
+  items: PartnerMerchant[]
+  pagination: {
+    page: number
+    limit: number
+    total: number
+    totalPages: number
+  }
+}
+
+export interface PartnerMerchantTransaction {
+  id: string
+  type: string
+  status: string
+  amount: number | string
+  currency: string
+  fee?: number | string
+  netAmount?: number | string
+  reference?: string | null
+  description?: string | null
+  mode?: string | null
+  channel?: string | null
+  partnerId?: string | null
+  partnerMerchantId?: string | null
+  createdAt: string
+  updatedAt?: string
+  processedAt?: string | null
+}
+
+export interface PartnerMerchantTransactionsResponse {
+  merchant: {
+    id: string
+    merchantId: string
+    merchantName: string
+    apiPartnerId: string
+    status: string
+  }
+  items: PartnerMerchantTransaction[]
+  pagination: {
+    page: number
+    limit: number
+    total: number
+    totalPages: number
+  }
+}
+
+export interface PartnerMerchantListParams {
+  apiPartnerId?: string
+  industry?: string
+  status?: string
+  search?: string
+  page?: number
+  limit?: number
+}
+
+function buildQuery(params: PartnerMerchantListParams = {}) {
+  const query = new URLSearchParams()
+  if (params.apiPartnerId) query.set('apiPartnerId', params.apiPartnerId)
+  if (params.industry) query.set('industry', params.industry)
+  if (params.status) query.set('status', params.status)
+  if (params.search) query.set('search', params.search)
+  if (params.page) query.set('page', String(params.page))
+  if (params.limit) query.set('limit', String(params.limit))
+  const qs = query.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export function usePartnerMerchants(params: PartnerMerchantListParams = {}) {
+  return useQuery({
+    queryKey: ['partner-merchants', params],
+    queryFn: async () => {
+      const response = await api.get(
+        `/api/v1/admin/partner-management/merchants${buildQuery(params)}`,
+      )
+      return response.data as PartnerMerchantListResponse
+    },
+    staleTime: 2 * 60 * 1000,
+  })
+}
+
+export function usePartnerMerchant(merchantId: string) {
+  return useQuery({
+    queryKey: ['partner-merchants', merchantId],
+    queryFn: async () => {
+      const response = await api.get(
+        `/api/v1/admin/partner-management/merchants/${encodeURIComponent(merchantId)}`,
+      )
+      return response.data as PartnerMerchant
+    },
+    enabled: Boolean(merchantId),
+    staleTime: 2 * 60 * 1000,
+  })
+}
+
+export function usePartnerMerchantTransactions(
+  merchantId: string,
+  page = 1,
+  limit = 20,
+) {
+  return useQuery({
+    queryKey: ['partner-merchants', merchantId, 'transactions', page, limit],
+    queryFn: async () => {
+      const response = await api.get(
+        `/api/v1/admin/partner-management/merchants/${encodeURIComponent(merchantId)}/transactions?page=${page}&limit=${limit}`,
+      )
+      return response.data as PartnerMerchantTransactionsResponse
+    },
+    enabled: Boolean(merchantId),
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useBlockPartnerMerchant() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: {
+      merchantId: string
+      blocked: boolean
+      reason?: string
+    }) => {
+      const response = await api.post(
+        `/api/v1/admin/partner-management/merchants/${encodeURIComponent(payload.merchantId)}/block`,
+        {
+          blocked: payload.blocked,
+          reason: payload.reason,
+        },
+      )
+      return response.data as PartnerMerchant
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['partner-merchants'] })
+      queryClient.invalidateQueries({
+        queryKey: ['partner-merchants', data.merchantId],
+      })
+    },
+  })
+}
+
+export function useUpdatePartnerMerchant() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: {
+      merchantId: string
+      merchantName?: string
+      industry?: string
+      contactEmail?: string
+      contactPhone?: string
+      contactPerson?: string
+      status?: 'ACTIVE' | 'INACTIVE'
+    }) => {
+      const { merchantId, ...body } = payload
+      const response = await api.patch(
+        `/api/v1/admin/partner-management/merchants/${encodeURIComponent(merchantId)}`,
+        body,
+      )
+      return response.data as PartnerMerchant
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['partner-merchants'] })
+      queryClient.invalidateQueries({
+        queryKey: ['partner-merchants', data.merchantId],
+      })
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- Add **Partner Merchants** nav item
- List page with partner / industry / status / search filters
- Detail page with profile, KYC documents, block/unblock, and attributed transactions
- Hook `usePartnerMerchants` wired to partner-management merchant APIs

## Test plan
- [ ] Open `/dashboard/partner-merchants` with `PARTNERS_VIEW`
- [ ] Filter by partner/status/industry and open a merchant detail
- [ ] Block then unblock a merchant; confirm reason shown when blocked
- [ ] Confirm KYC docs and transactions sections load